### PR TITLE
Remove redundant title text overlays from movie content

### DIFF
--- a/packages/shared-ui/src/screens/DetailsScreen.tsx
+++ b/packages/shared-ui/src/screens/DetailsScreen.tsx
@@ -67,8 +67,6 @@ export default function DetailsScreen() {
         <Image source={imageSource} style={detailsStyles.backgroundImage} />
         <View style={detailsStyles.contentContainer}>
           <View style={detailsStyles.topContent}>
-            <Text style={detailsStyles.title}>{title}</Text>
-
             {/* Metadata row */}
             <View style={detailsStyles.metadataRow}>
               {releaseYear && (

--- a/packages/shared-ui/src/screens/DetailsScreen.tsx
+++ b/packages/shared-ui/src/screens/DetailsScreen.tsx
@@ -67,6 +67,8 @@ export default function DetailsScreen() {
         <Image source={imageSource} style={detailsStyles.backgroundImage} />
         <View style={detailsStyles.contentContainer}>
           <View style={detailsStyles.topContent}>
+            <Text style={detailsStyles.title}>{title}</Text>
+
             {/* Metadata row */}
             <View style={detailsStyles.metadataRow}>
               {releaseYear && (

--- a/packages/shared-ui/src/screens/HomeScreen.tsx
+++ b/packages/shared-ui/src/screens/HomeScreen.tsx
@@ -44,9 +44,6 @@ const MovieItem = React.memo(
           onError={(error) => console.log('Image load error:', item.title, error.nativeEvent.error)}
           onLoad={() => console.log('Image loaded:', item.title)}
         />
-        <View style={styles.thumbnailTextContainer}>
-          <Text style={styles.thumbnailText} numberOfLines={2}>{item.title}</Text>
-        </View>
       </View>
     );
   },
@@ -102,19 +99,6 @@ export default function HomeScreen() {
             source={headerImageSource}
             resizeMode="cover"
           />
-          {/* Linear gradient scrim for left overlay */}
-          <PlatformLinearGradient
-            colors={['rgba(0,0,0,0.9)', 'rgba(0,0,0,0.7)', 'rgba(0,0,0,0.3)', 'transparent']}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 0 }}
-            style={gridStyles.gradientLeft}
-          />
-          <View style={gridStyles.headerTextContainer}>
-            <Text style={gridStyles.headerTitle}>{focusedItem.title}</Text>
-            <Text style={gridStyles.headerDescription} numberOfLines={3}>
-              {focusedItem.description}
-            </Text>
-          </View>
         </View>
       );
     },


### PR DESCRIPTION
The banner images already contain the movie title/logo, so the text overlays were redundant. This follows standard media app practices where the title is embedded in the banner image itself.

Changes:
- Removed title and description text overlay from HomeScreen header
- Removed title text overlay from MovieItem thumbnail cards
- Removed title text overlay from DetailsScreen

## Type of change
-  🎨 Style